### PR TITLE
allow to configure with KUBECONFIG env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea
-cmd/eks-node-viewer/eks-node-viewer
+.vscode
 eks-node-viewer

--- a/cmd/eks-node-viewer/main.go
+++ b/cmd/eks-node-viewer/main.go
@@ -3,6 +3,19 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
 	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
@@ -17,6 +30,8 @@ import (
 	"context"
 	"flag"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -29,19 +44,30 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/homedir"
 
 	"github.com/awslabs/eks-node-viewer/pkg/client"
 	"github.com/awslabs/eks-node-viewer/pkg/model"
 	"github.com/awslabs/eks-node-viewer/pkg/pricing"
 )
 
+var kubeconfig *string
+
 func main() {
 	nodeSelectorFlag := flag.String("nodeSelector", "", "Node label selector used to filter nodes, if empty all nodes are selected ")
 	resources := flag.String("resources", "cpu", "List of comma separated resources to monitor")
 	disablePricing := flag.Bool("disable-pricing", false, "Disable pricing lookups")
-
+	if home := homedir.HomeDir(); home != "" {
+		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	}
 	flag.Parse()
-	cs, err := client.Create()
+	kubeconfigenv := os.Getenv("KUBECONFIG")
+	if len(kubeconfigenv) != 0 {	
+		kubeconfig = &kubeconfigenv
+	}
+	cs, err := client.Create(kubeconfig)
 	if err != nil {
 		log.Fatalf("creating client, %s", err)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -28,26 +28,12 @@ limitations under the License.
 package client
 
 import (
-	"flag"
-	"path/filepath"
-
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // pull auth
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 )
 
-var kubeconfig *string
-
-func init() {
-	if home := homedir.HomeDir(); home != "" {
-		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-	} else {
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
-	}
-}
-
-func Create() (*kubernetes.Clientset, error) {
+func Create(kubeconfig *string) (*kubernetes.Clientset, error) {
 	// use the current context in kubeconfig
 	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Like kubectl, k9s.. it is useful to have different directories with different KUBECONFIG env var.
This change allow to point to the cluster targeted by the KUBECONFIG env var


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
