### PR TITLE
Read from KUBECONFIG env if set

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -29,6 +29,7 @@ package client
 
 import (
 	"flag"
+	"os"
 	"path/filepath"
 
 	"k8s.io/client-go/kubernetes"
@@ -40,14 +41,20 @@ import (
 var kubeconfig *string
 
 func init() {
+	kubeEnv, kubeEnvExists := os.LookupEnv("KUBECONFIG")
 	if home := homedir.HomeDir(); home != "" {
-		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+		if kubeEnvExists {
+			kubeconfig = flag.String("kubeconfig", kubeEnv, "absolute path to the kubeconfig file")
+		} else {
+			kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+		}
 	} else {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	}
 }
 
 func Create() (*kubernetes.Clientset, error) {
+
 	// use the current context in kubeconfig
 	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	if err != nil {


### PR DESCRIPTION
*Description of changes:*
Allows the tool to read the KUBECONFIG environment variable if it is set. Can still be overridden with `-kubeconfig` flag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
