### PR TITLE
feat: Add release workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # disable shallow clone - get all
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+      id: go
+
+    - name: Generate build tag
+      run: |
+        VERSION=${GITHUB_REF#refs/tags/}
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+      shell: /bin/bash -e {0}
+
+    - name: Print build tag
+      run: echo "${VERSION}"
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v3
+      with:
+        version: latest
+        args: release --rm-dist
+        workdir: .
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION: ${{ env.VERSION }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 cmd/eks-node-viewer/eks-node-viewer
 eks-node-viewer
 coverage.out
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,50 @@
+project_name: eks-node-viewer
+
+source:
+  enabled: false
+
+before:
+  hooks:
+  - go mod download
+
+builds:
+  - binary: eks-node-viewer
+    main: ./cmd/eks-node-viewer
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    targets:
+      - linux_amd64
+      - windows_amd64
+      - darwin_amd64
+      - darwin_arm64
+    env:
+      - CGO_ENABLED=0
+
+    flags:
+      - -v
+
+universal_binaries:
+ - replace: true
+
+archives:
+  -
+    format_overrides:
+      - goos: windows
+        format: zip
+
+release:
+  prerelease: auto
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_sha256_checksums.txt"
+  algorithm: sha256
+
+changelog:
+  skip: false
+  use: git # github(-native)
+  sort: asc


### PR DESCRIPTION
*Issue #, if available:*
Fixes: #13 

*Description of changes:*
Adds GHA workflow to build releases on tags: `v*`. After this is introduced it would make sense to build in app version and corresponding CLI command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
