### PR TITLE
Add -context flag and add multi-path KUBECONFIG support

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // pull auth
@@ -26,6 +27,7 @@ import (
 )
 
 var kubeconfig *string
+var context *string
 
 func init() {
 	kubeEnv, kubeEnvExists := os.LookupEnv("KUBECONFIG")
@@ -38,12 +40,16 @@ func init() {
 	} else {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	}
+	context = flag.String("context", "", "name of the kubernetes context to use")
 }
 
 func Create() (*kubernetes.Clientset, error) {
 
 	// use the current context in kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{Precedence: strings.Split(*kubeconfig, ":")},
+		&clientcmd.ConfigOverrides{CurrentContext: *context}).ClientConfig()
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
*Issue #, if available:*

* KUBECONFIG issue reported here: https://github.com/awslabs/eks-node-viewer/issues/31
* I can't find an issue for adding `-context`, but it's useful to me

*Description of changes:*

This PR adds a -context flag that allows the kubernetes context to be overridden just for the current command

I've also changed how the kubeconfig value is used so that we use Precedence instead of an absolute path - kubectl allows you to set multiple files in your KUBECONFIG environment variable (eg <path_1>:<path_2>) and BuildConfigFromFlags doesn't support this

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
