### PR TITLE
docs: fix default kube config file in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Usage of ./eks-node-viewer:
   -extra-labels string
     	A comma separated set of extra node labels to display
   -kubeconfig string
-    	Absolute path to the kubeconfig file (default "/Users/tnealt/.kube/config")
+    	Absolute path to the kubeconfig file (default "~/.kube/config")
   -node-selector string
     	Node label selector used to filter nodes, if empty all nodes are selected
   -resources string


### PR DESCRIPTION

*Description of changes:*

- fix the default Kube config file in readme

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
