### PR TITLE
Exclude failed and succeeded pods

### DIFF
--- a/cmd/eks-node-viewer/main.go
+++ b/cmd/eks-node-viewer/main.go
@@ -114,7 +114,7 @@ func startMonitor(ctx context.Context, settings *monitorSettings) {
 				}
 				pod, ok := cluster.GetPod(p.Namespace, p.Name)
 				if pod.IsCompleted() {
-					cluster.DeletePod(p.Namespace, p.Name)
+					cluster.DeletePod(pod.Namespace, pod.Name)
 					return
 				}
 				if !ok {

--- a/cmd/eks-node-viewer/main.go
+++ b/cmd/eks-node-viewer/main.go
@@ -114,7 +114,7 @@ func startMonitor(ctx context.Context, settings *monitorSettings) {
 				}
 				pod, ok := cluster.GetPod(p.Namespace, p.Name)
 				if pod.IsCompleted() {
-					cluster.DeletePod(pod.Namespace, pod.Name)
+					cluster.DeletePod(pod.Namespace(), pod.Name())
 					return
 				}
 				if !ok {

--- a/cmd/eks-node-viewer/main.go
+++ b/cmd/eks-node-viewer/main.go
@@ -113,14 +113,16 @@ func startMonitor(ctx context.Context, settings *monitorSettings) {
 					return
 				}
 				pod, ok := cluster.GetPod(p.Namespace, p.Name)
-				if pod.IsCompleted() {
-					cluster.DeletePod(pod.Namespace(), pod.Name())
-					return
-				}
 				if !ok {
 					cluster.AddPod(model.NewPod(p), settings.pricing)
 					return
 				}
+
+				if pod.IsCompleted() {
+					cluster.DeletePod(pod.Namespace(), pod.Name())
+					return
+				}
+
 				pod.Update(p)
 				cluster.AddPod(pod, settings.pricing)
 			},

--- a/cmd/eks-node-viewer/main.go
+++ b/cmd/eks-node-viewer/main.go
@@ -108,7 +108,7 @@ func startMonitor(ctx context.Context, settings *monitorSettings) {
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				p := newObj.(*v1.Pod)
-				if !p.DeletionTimestamp.IsZero() {
+				if !p.DeletionTimestamp.IsZero() || p.Status.Phase == v1.PodSucceeded || p.Status.Phase == v1.PodFailed {
 					cluster.DeletePod(p.Namespace, p.Name)
 					return
 				}
@@ -117,12 +117,6 @@ func startMonitor(ctx context.Context, settings *monitorSettings) {
 					cluster.AddPod(model.NewPod(p), settings.pricing)
 					return
 				}
-
-				if pod.IsCompleted() {
-					cluster.DeletePod(pod.Namespace(), pod.Name())
-					return
-				}
-
 				pod.Update(p)
 				cluster.AddPod(pod, settings.pricing)
 			},

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -78,11 +78,7 @@ func (c *Cluster) AddPod(pod *Pod, pprov *pricing.Provider) (totalPods int) {
 	totalPods = len(c.pods)
 	c.mu.Unlock()
 
-	if !pod.IsScheduled() {
-		return
-	}
-
-	if pod.Phase() == v1.PodSucceeded || pod.Phase() == v1.PodFailed {
+	if !pod.IsScheduled() || pod.IsCompleted() {
 		return
 	}
 

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -81,6 +81,11 @@ func (c *Cluster) AddPod(pod *Pod, pprov *pricing.Provider) (totalPods int) {
 	if !pod.IsScheduled() {
 		return
 	}
+
+	if pod.Phase() == v1.PodSucceeded || pod.Phase() == v1.PodFailed {
+		return
+	}
+
 	n, ok := c.GetNode(pod.NodeName())
 	if !ok {
 		// node doesn't exist so we need to create it first to have somewhere to record the pod, it will be updated

--- a/pkg/model/pod.go
+++ b/pkg/model/pod.go
@@ -76,6 +76,16 @@ func (p *Pod) Phase() v1.PodPhase {
 	return p.pod.Status.Phase
 }
 
+// IsCompleted returns true if the pod is not running anymore (failed or completed)
+func (p *Pod) IsCompleted() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.Phase() == v1.PodSucceeded || p.Phase() == v1.PodFailed {
+		return true
+	}
+	return false
+}
+
 // Requested returns the sum of the resources requested by the pod. This doesn't include any init containers as we
 // are interested in the steady state usage of the pod
 func (p *Pod) Requested() v1.ResourceList {

--- a/pkg/model/uimodel.go
+++ b/pkg/model/uimodel.go
@@ -70,8 +70,8 @@ func (u *UIModel) View() string {
 	ctw.Flush()
 	u.progress.ShowPercentage = true
 
-	fmt.Fprintf(&b, "%d pods (%d pending, %d running, %d bound, %d completed, %d failed)\n", stats.TotalPods,
-		stats.PodsByPhase[v1.PodPending], stats.PodsByPhase[v1.PodRunning], stats.BoundPodCount, stats.PodsByPhase[v1.PodSucceeded], stats.PodsByPhase[v1.PodFailed])
+	fmt.Fprintf(&b, "%d pods (%d bound, %d pending, %d running, %d completed, %d failed)\n", stats.TotalPods,
+		stats.BoundPodCount, stats.PodsByPhase[v1.PodPending], stats.PodsByPhase[v1.PodRunning], stats.PodsByPhase[v1.PodSucceeded], stats.PodsByPhase[v1.PodFailed])
 
 	fmt.Fprintln(&b)
 	for _, n := range stats.Nodes {

--- a/pkg/model/uimodel.go
+++ b/pkg/model/uimodel.go
@@ -70,8 +70,8 @@ func (u *UIModel) View() string {
 	ctw.Flush()
 	u.progress.ShowPercentage = true
 
-	fmt.Fprintf(&b, "%d pods (%d pending %d running %d bound)\n", stats.TotalPods,
-		stats.PodsByPhase[v1.PodPending], stats.PodsByPhase[v1.PodRunning], stats.BoundPodCount)
+	fmt.Fprintf(&b, "%d pods (%d pending, %d running, %d bound, %d completed, %d failed)\n", stats.TotalPods,
+		stats.PodsByPhase[v1.PodPending], stats.PodsByPhase[v1.PodRunning], stats.BoundPodCount, stats.PodsByPhase[v1.PodSucceeded], stats.PodsByPhase[v1.PodFailed])
 
 	fmt.Fprintln(&b)
 	for _, n := range stats.Nodes {


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/eks-node-viewer/issues/40

*Description of changes:*

Exclude to add pods which are already completed or which failed. 
Keep them in total pod count, but added also the count of succeeded and failed pods to summary


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
