### PR TITLE
Fix color gradient (green to red instead of red to green)

### DIFF
--- a/pkg/model/uimodel.go
+++ b/pkg/model/uimodel.go
@@ -39,7 +39,7 @@ type UIModel struct {
 func NewUIModel(extraLabels []string) *UIModel {
 	return &UIModel{
 		// red to green
-		progress:    progress.New(progress.WithGradient("#ff0000", "#04B575")),
+		progress:    progress.New(progress.WithGradient("#04B575", "#ff0000")),
 		cluster:     NewCluster(),
 		extraLabels: extraLabels,
 	}
@@ -152,11 +152,11 @@ func (u *UIModel) writeClusterSummary(resources []v1.ResourceName, stats Stats, 
 		}
 		pctUsedStr := fmt.Sprintf("%0.1f%%", pctUsed)
 		if pctUsed > 90 {
-			pctUsedStr = green(pctUsedStr)
+			pctUsedStr = red(pctUsedStr)
 		} else if pctUsed > 60 {
 			pctUsedStr = yellow(pctUsedStr)
 		} else {
-			pctUsedStr = red(pctUsedStr)
+			pctUsedStr = green(pctUsedStr)
 		}
 
 		u.progress.ShowPercentage = false


### PR DESCRIPTION
*Description of changes:*

Switch color gradient, from green to red instead of red to green
Also the total count of CPU, use color red if cpu is over 90% and use green if its below 60%

BEFORE
![SCR-20221221-e6x](https://user-images.githubusercontent.com/1647861/208869650-935b3dbf-3382-4445-a814-b37e63a1e4e4.png)

AFTER
![SCR-20221221-e69](https://user-images.githubusercontent.com/1647861/208869669-a68b1024-5ebc-4866-902a-ea367e72b4c1.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
