### PR TITLE
fix: re-price nodes after every pricing update

### DIFF
--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -65,6 +65,14 @@ func (c *Cluster) DeleteNode(name string) {
 	}
 }
 
+func (c *Cluster) ForEachNode(f func(n *Node)) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, n := range c.nodes {
+		f(n)
+	}
+}
+
 func (c *Cluster) GetNode(name string) (*Node, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -143,7 +151,7 @@ func (c *Cluster) Stats() Stats {
 		}
 		// only add the price if it's not NaN which is used to indicate an unknown
 		// price
-		if n.Price == n.Price {
+		if n.HasPrice() {
 			st.TotalPrice += n.Price
 		}
 		st.NumNodes++


### PR DESCRIPTION
Previously there was a race between pricing updates and node creation. If the pricing updated first, you would get new pricing (OD & Spot) for nodes.  If the nodes were created first, you would use stale OD pricing and not have spot pricing.  This change forces all nodes to have their prices re-calculated after every pricing update.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
