### PR TITLE
enable aws sdk shared config

### DIFF
--- a/cmd/eks-node-viewer/main.go
+++ b/cmd/eks-node-viewer/main.go
@@ -77,7 +77,7 @@ func main() {
 	m.SetResources(strings.FieldsFunc(flags.Resources, func(r rune) bool { return r == ',' }))
 
 	if !flags.DisablePricing {
-		sess := session.Must(session.NewSession(nil))
+		sess := session.Must(session.NewSessionWithOptions(session.Options{SharedConfigState: session.SharedConfigEnable}))
 		updateAllPrices := func() {
 			m.Cluster().ForEachNode(func(n *model.Node) {
 				n.UpdatePrice(pprov)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - Enables AWS SDK [Shared Config](https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#:~:text=Shared%20Config%20Fields) (i.e. `~/.aws/config`) '

Load order is still the same since Shared Config is loaded after everything except IMDS:
1. Environment Variables
1. Shared Credentials file
1. Shared Configuration file (if SharedConfig is enabled)
1. EC2 Instance Metadata (credentials only)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
