### PR TITLE
Report accurate notready time

### DIFF
--- a/cmd/eks-node-viewer/main.go
+++ b/cmd/eks-node-viewer/main.go
@@ -100,7 +100,7 @@ func main() {
 		pricing:      pprov,
 	}
 	startMonitor(ctx, monitorSettings)
-	if err := tea.NewProgram(m, tea.WithAltScreen()).Start(); err != nil {
+	if _, err := tea.NewProgram(m, tea.WithAltScreen()).Run(); err != nil {
 		log.Fatalf("error running tea: %s", err)
 	}
 	cancel()
@@ -126,7 +126,7 @@ func startMonitor(ctx context.Context, settings *monitorSettings) {
 			AddFunc: func(obj interface{}) {
 				p := obj.(*v1.Pod)
 				if !isTerminalPod(p) {
-					cluster.AddPod(model.NewPod(p), settings.pricing)
+					cluster.AddPod(model.NewPod(p))
 					node, ok := cluster.GetNode(p.Spec.NodeName)
 					// need to potentially update node price as we need the fargate pod in order to figure out the cost
 					if ok && node.IsFargate() && !node.HasPrice() {
@@ -145,10 +145,10 @@ func startMonitor(ctx context.Context, settings *monitorSettings) {
 				} else {
 					pod, ok := cluster.GetPod(p.Namespace, p.Name)
 					if !ok {
-						cluster.AddPod(model.NewPod(p), settings.pricing)
+						cluster.AddPod(model.NewPod(p))
 					} else {
 						pod.Update(p)
-						cluster.AddPod(pod, settings.pricing)
+						cluster.AddPod(pod)
 					}
 				}
 			},

--- a/hack/boilerplate.go
+++ b/hack/boilerplate.go
@@ -48,7 +48,7 @@ func main() {
 	}
 }
 
-func addLicense(path string, d fs.DirEntry, err error) error {
+func addLicense(path string, _ fs.DirEntry, err error) error {
 	if !strings.HasSuffix(path, ".go") {
 		return nil
 	}

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -20,8 +20,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/awslabs/eks-node-viewer/pkg/pricing"
 )
 
 type Cluster struct {
@@ -80,7 +78,7 @@ func (c *Cluster) GetNode(name string) (*Node, bool) {
 	return n, ok
 }
 
-func (c *Cluster) AddPod(pod *Pod, pprov *pricing.Provider) (totalPods int) {
+func (c *Cluster) AddPod(pod *Pod) (totalPods int) {
 	c.mu.Lock()
 	c.pods[objectKey{namespace: pod.Namespace(), name: pod.Name()}] = pod
 	totalPods = len(c.pods)

--- a/pkg/model/uimodel.go
+++ b/pkg/model/uimodel.go
@@ -164,7 +164,7 @@ func (u *UIModel) writeNodeInfo(n *Node, w io.Writer, resources []v1.ResourceNam
 			if n.Ready() {
 				fmt.Fprintf(w, "\tReady")
 			} else {
-				fmt.Fprintf(w, "\t%s", duration.HumanDuration(time.Since(n.Created())))
+				fmt.Fprintf(w, "\tNotReady/%s", duration.HumanDuration(time.Since(n.NotReadyTime())))
 			}
 
 			for _, label := range u.extraLabels {

--- a/pkg/pricing/pricing.go
+++ b/pkg/pricing/pricing.go
@@ -420,7 +420,7 @@ func (p *Provider) updateSpotPricing(ctx context.Context) error {
 	return nil
 }
 
-func (p *Provider) LivenessProbe(req *http.Request) error {
+func (p *Provider) LivenessProbe(_ *http.Request) error {
 	// ensure we don't deadlock and nolint for the empty critical section
 	p.mu.Lock()
 	//nolint: staticcheck

--- a/pkg/pricing/zz_generated.pricing.go
+++ b/pkg/pricing/zz_generated.pricing.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package pricing
 
 import "time"

--- a/pkg/text/colortabwriter.go
+++ b/pkg/text/colortabwriter.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package text
 
 import (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes an issue where we would sometimes report an inaccurate node NotReady time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
