### PR TITLE
feat: add karpenter.sh/disruption taint as cordon state

### DIFF
--- a/cmd/eks-node-viewer/main.go
+++ b/cmd/eks-node-viewer/main.go
@@ -189,7 +189,7 @@ func startMonitor(ctx context.Context, settings *monitorSettings) {
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				n := newObj.(*v1.Node)
-				if !n.DeletionTimestamp.IsZero() {
+				if !n.DeletionTimestamp.IsZero() && len(n.Finalizers) == 0 {
 					cluster.DeleteNode(n.Spec.ProviderID)
 				} else {
 					node, ok := cluster.GetNode(n.Spec.ProviderID)

--- a/pkg/model/node.go
+++ b/pkg/model/node.go
@@ -182,7 +182,15 @@ func (n *Node) Used() v1.ResourceList {
 func (n *Node) Cordoned() bool {
 	n.mu.RLock()
 	defer n.mu.RUnlock()
-	return n.node.Spec.Unschedulable
+	if n.node.Spec.Unschedulable {
+		return true
+	}
+	for _, taint := range n.node.Spec.Taints {
+		if taint.Key == "karpenter.sh/disruption" && taint.Effect == v1.TaintEffectNoSchedule {
+			return true
+		}
+	}
+	return false
 }
 
 func (n *Node) Ready() bool {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - Add Karpenter's v1beta1 karpenter.sh/disruption taint as one of the possible cordon states in node-viewer
 - check that no finalizers exist before deleting a node from the OnUpdate func of the node informer
   - This was resulting in nodes to vanish from the screen before they were actually deleted.  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
