### PR TITLE
fix: remove deprecated options in goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
       with:
         distribution: goreleaser
         version: latest
-        args: release --rm-dist
+        args: release --clean
         workdir: .
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,13 +10,6 @@ before:
 builds:
   - binary: eks-node-viewer
     main: ./cmd/eks-node-viewer
-    goos:
-      - linux
-      - darwin
-      - windows
-    goarch:
-      - amd64
-      - arm64
     targets:
       - linux_amd64
       - linux_arm64

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: generate ## Build
 	go build -ldflags="-s -w -X main.version=local -X main.builtBy=Makefile" ./cmd/eks-node-viewer
 
 goreleaser: ## Release snapshot
-	goreleaser build --snapshot --rm-dist
+	goreleaser build --snapshot --clean
 
 download: ## Download dependencies
 	go mod download


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
On v0.6.0 release:
```
  • DEPRECATED: --rm-dist was deprecated in favor of --clean, check https://goreleaser.com/deprecations#-rm-dist for more details
  • loading environment variables
    • using token from $GITHUB_TOKEN
  • getting and validating git state
    • git state                                      commit=e45ef3df0d6efbf25693f7d16c103593f8a3c006 branch=HEAD current_tag=v0.6.0 previous_tag=v0.5.0 dirty=false
  • parsing tag
  • setting defaults
    • builds.goos is ignored when builds.targets is set
    • builds.goarch is ignored when builds.targets is set
```

 - Replaced --rm-dist with clean
 - Removed goos and goarch since they aren't used if targets are provided.

Tested locally with `make goreleaser`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
