### PR TITLE
include resources for sidecar init containers

### DIFF
--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -159,8 +159,8 @@ func TestClusterAddPod(t *testing.T) {
 		t.Errorf("expected 0 pods, got %d", got)
 	}
 
-	if got := cluster.Stats().UsedResources["cpu"]; got.Cmp(resource.MustParse("1")) != 0 {
-		t.Errorf("expected 1 CPU used, got %s", got.String())
+	if got := cluster.Stats().UsedResources["cpu"]; got.Cmp(resource.MustParse("2")) != 0 {
+		t.Errorf("expected 2 CPU used, got %s", got.String())
 	}
 
 	// deleting the pod should remove the usage
@@ -194,8 +194,8 @@ func TestClusterDeleteNodeDeletesPods(t *testing.T) {
 		t.Errorf("expected 0 pods, got %d", got)
 	}
 
-	if got := cluster.Stats().UsedResources["cpu"]; got.Cmp(resource.MustParse("1")) != 0 {
-		t.Errorf("expected 1 CPU used, got %s", got.String())
+	if got := cluster.Stats().UsedResources["cpu"]; got.Cmp(resource.MustParse("2")) != 0 {
+		t.Errorf("expected 2 CPU used, got %s", got.String())
 	}
 
 	// deleting the node should clear all of the usage of pods that were bound to the node


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/

include resources for init containers that are actually sidecars. this is available since 1.28


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
