### PR TITLE
Fix duplicate AWS pricing initialization

### DIFF
--- a/pkg/aws/pricing.go
+++ b/pkg/aws/pricing.go
@@ -115,7 +115,7 @@ func NewPricingAPI(sess *session.Session, region string) pricingiface.PricingAPI
 var allPrices = []map[string]map[string]float64{
 	InitialOnDemandPricesAWS,
 	InitialOnDemandPricesUSGov,
-	InitialOnDemandPricesUSGov,
+	InitialOnDemandPricesCN,
 }
 
 func getStaticPrices(region string) map[string]float64 {


### PR DESCRIPTION
*Issue #, if available:*

NONE

*Description of changes:*

AWS pricing initialization where InitialOnDemandPricesUSGov was mistakenly duplicated. The correct InitialOnDemandPricesCN is now included in the allPrices variable. This ensures proper initialization of pricing data for the China region.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
