### PR TITLE
Label names displayed as-Is when nodes lack the specified labels

### DIFF
--- a/pkg/model/node.go
+++ b/pkg/model/node.go
@@ -296,7 +296,7 @@ func (n *Node) ComputeLabel(labelName string) string {
 	if match := resourceLabelRe.FindStringSubmatch(labelName); len(match) > 0 {
 		return pctUsage(n.Allocatable(), n.Used(), match[1])
 	}
-	return labelName
+	return "-"
 }
 
 // NotReadyTime is the time that the node went NotReady, or when it was created if it hasn't been marked as NotReady.

--- a/pkg/model/uimodel.go
+++ b/pkg/model/uimodel.go
@@ -183,9 +183,6 @@ func (u *UIModel) writeNodeInfo(n *Node, w io.Writer, resources []v1.ResourceNam
 				if !ok {
 					// support computed label values
 					labelValue = n.ComputeLabel(label)
-					if labelValue == label {
-						labelValue = "-"
-					}
 				}
 				fmt.Fprintf(w, "\t%s", labelValue)
 			}

--- a/pkg/model/uimodel.go
+++ b/pkg/model/uimodel.go
@@ -183,6 +183,9 @@ func (u *UIModel) writeNodeInfo(n *Node, w io.Writer, resources []v1.ResourceNam
 				if !ok {
 					// support computed label values
 					labelValue = n.ComputeLabel(label)
+					if labelValue == label {
+						labelValue = "-"
+					}
 				}
 				fmt.Fprintf(w, "\t%s", labelValue)
 			}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When specifying custom labels with the -extra-labels option, if a node does not have the specified label, the label name is displayed as-is.


For example, if you specify a label such as type using the following command:
```sh
$ eks-node-viewer -extra-labels type,eks-node-viewer/node-age -node-sort type
```

The output may look like this:
```
26 nodes (156331m/205660m) 76.0% cpu ██████████████████████████████░░░░░░░░░░ $6.115/hour | $4,463.950/month
350 pods (2 pending 348 running 350 bound)

ip-172-30-22-56.ap-northeast-1.compute.internal  cpu █████████████████████████████████░░  95% (13 pods) m7i.2xlarge/$0.4032 On-Demand -        Ready type       3d3h
ip-172-30-26-26.ap-northeast-1.compute.internal  cpu ███████████████████████████████░░░░  89% (14 pods) m7i.2xlarge/$0.4032 On-Demand -        Ready type       3d1h
ip-172-30-27-21.ap-northeast-1.compute.internal  cpu ███████████████████████████████░░░░  89% (10 pods) m7i.2xlarge/$0.4032 On-Demand -        Ready type       2d1h
ip-172-30-26-252.ap-northeast-1.compute.internal cpu ███████████████████████████████░░░░  89% (10 pods) m7i.2xlarge/$0.4032 On-Demand -        Ready type       2d1h
ip-172-30-23-219.ap-northeast-1.compute.internal cpu ███████████████████████████████░░░░  89% (10 pods) m7i.2xlarge/$0.4032 On-Demand -        Ready type       2d1h
ip-172-30-23-39.ap-northeast-1.compute.internal  cpu ████████████████████████████████░░░  92% (9 pods)  m7i.2xlarge/$0.4032 On-Demand -        Ready type       2d1h
ip-172-30-27-251.ap-northeast-1.compute.internal cpu ██████████████████████████████░░░░░  86% (9 pods)  m7i.2xlarge/$0.4032 On-Demand -        Ready type       2d1h
ip-172-30-27-125.ap-northeast-1.compute.internal cpu ███████████████████████████░░░░░░░░  76% (8 pods)  m6g.2xlarge/$0.1892 Spot      -        Ready apm        47h
ip-172-30-21-20.ap-northeast-1.compute.internal  cpu ██████████████████████████░░░░░░░░░  74% (8 pods)  m7g.2xlarge/$0.1721 Spot      -        Ready apm        24h
ip-172-30-21-207.ap-northeast-1.compute.internal cpu ███████████░░░░░░░░░░░░░░░░░░░░░░░░  32% (9 pods)  m7g.2xlarge/$0.1721 Spot      Cordoned Ready monitoring 18h
ip-172-30-21-136.ap-northeast-1.compute.internal cpu ███████████████████████████████████ 100% (18 pods) m7g.2xlarge/$0.1721 Spot      -        Ready type       17h
ip-172-30-22-189.ap-northeast-1.compute.internal cpu ███████████████████████████████████ 100% (28 pods) m7g.2xlarge/$0.1721 Spot      -        Ready type       17h
```

To address this, I modified the behavior so that if labels other than `eks-node-viewer/node-age` or `eks-node-viewer/node-xxx-usage` are specified, and a node does not have the specified label, a `-` will be displayed instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
