### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ extra-labels=topology.kubernetes.io/zone,karpenter.sh/nodepool
 
 # sort so that the newest nodes are first
 node-sort=creation=asc
+
+# change default color style
+style=#2E91D2,#ffff00,#D55E00
 ```
 
 ### Troubleshooting


### PR DESCRIPTION
Add Default Options example to help colorblind users know how to configure settings globally. 

Example colors help users with Deuteranopia (Difficulty distinguishing between reds, greens and yellows)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
