### PR TITLE
fix: skip nodes with empty provider-id

### DIFF
--- a/pkg/client/controller.go
+++ b/pkg/client/controller.go
@@ -15,7 +15,6 @@ package client
 
 import (
 	"context"
-	"log"
 	"math"
 	"strconv"
 	"time"
@@ -121,6 +120,9 @@ func (m Controller) startNodeWatch(ctx context.Context, cluster *model.Cluster) 
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				node := model.NewNode(obj.(*v1.Node))
+				if node.ProviderID() == "" {
+					return
+				}
 				m.updatePrice(node)
 				n := cluster.AddNode(node)
 				n.Show()
@@ -134,13 +136,11 @@ func (m Controller) startNodeWatch(ctx context.Context, cluster *model.Cluster) 
 					cluster.DeleteNode(n.Spec.ProviderID)
 				} else {
 					node, ok := cluster.GetNode(n.Spec.ProviderID)
-					if !ok {
-						log.Println("unable to find node", n.Name)
-					} else {
+					if ok {
 						node.Update(n)
 						m.updatePrice(node)
+						node.Show()
 					}
-					node.Show()
 				}
 			},
 		},


### PR DESCRIPTION
*Description of changes:*

In some cloud environments, Kubernetes nodes may join without a properly set provider ID. Only the CCM can define it.
As a result, if the provider ID is empty, it creates two records for the same node in the nodes map.

Thank you for this project!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
