### PR TITLE
Use AWS region & profile from kube context

### DIFF
--- a/pkg/aws/pricing.go
+++ b/pkg/aws/pricing.go
@@ -128,10 +128,12 @@ func getStaticPrices(region string) map[ec2types.InstanceType]float64 {
 	return InitialOnDemandPricesAWS["us-east-1"]
 }
 
-func NewStaticPricingProvider() nvp.Provider {
-	region := os.Getenv("AWS_REGION")
+func NewStaticPricingProvider(region string) nvp.Provider {
 	if region == "" {
-		region = "us-east-1"
+		region := os.Getenv("AWS_REGION")
+		if region == "" {
+			region = "us-east-1"
+		}
 	}
 
 	return &pricingProvider{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use the AWS region & profile configured in the kubeconfig.
It use the raw kubeconfig to retrieve the info from the user's exec envs & args fields.
It assume the use of `awscli`or `aws-iam-authenticator` in exec (they both use the same envs & args).

This allow to call  `eks-node-viewer` without the need to set the `AWS_PROFILE` or `AWS_REGION` env vars.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
