### PR TITLE
feat: add support for showing the normalized node allocation based on the higher allocated dimension among CPU and Memory

### DIFF
--- a/cmd/eks-node-viewer/flag.go
+++ b/cmd/eks-node-viewer/flag.go
@@ -41,16 +41,17 @@ func init() {
 }
 
 type Flags struct {
-	Context         string
-	NodeSelector    string
-	ExtraLabels     string
-	NodeSort        string
-	Style           string
-	Kubeconfig      string
-	Resources       string
-	DisablePricing  bool
-	ShowAttribution bool
-	Version         bool
+	Context              string
+	NodeSelector         string
+	ExtraLabels          string
+	NodeSort             string
+	Style                string
+	Kubeconfig           string
+	Resources            string
+	DisablePricing       bool
+	ShowAttribution      bool
+	NormalizedAllocation bool
+	Version              bool
 }
 
 func ParseFlags() (Flags, error) {
@@ -91,6 +92,8 @@ func ParseFlags() (Flags, error) {
 	flagSet.BoolVar(&flags.DisablePricing, "disable-pricing", disablePricingDefault, "Disable pricing lookups")
 
 	flagSet.BoolVar(&flags.ShowAttribution, "attribution", false, "Show the Open Source Attribution")
+
+	flagSet.BoolVar(&flags.NormalizedAllocation, "normalized-allocation", false, "Normalize the node allocation based on the higher allocated dimension among CPU and Memory")
 
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		return Flags{}, err

--- a/cmd/eks-node-viewer/main.go
+++ b/cmd/eks-node-viewer/main.go
@@ -58,6 +58,15 @@ func main() {
 		os.Exit(0)
 	}
 
+	resources := strings.FieldsFunc(flags.Resources, func(r rune) bool { return r == ',' })
+	if flags.NormalizedAllocation {
+		for _, res := range resources {
+			if res != "cpu" && res != "memory" {
+				log.Fatalf("normalized allocation only supports cpu and memory, got %s", res)
+			}
+		}
+	}
+
 	cs, err := client.NewKubernetes(flags.Kubeconfig, flags.Context)
 	if err != nil {
 		log.Fatalf("creating client, %s", err)
@@ -73,9 +82,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("creating style, %s", err)
 	}
-	m := model.NewUIModel(strings.Split(flags.ExtraLabels, ","), flags.NodeSort, style)
+	m := model.NewUIModel(strings.Split(flags.ExtraLabels, ","), flags.NodeSort, style, flags.NormalizedAllocation)
 	m.DisablePricing = flags.DisablePricing
-	m.SetResources(strings.FieldsFunc(flags.Resources, func(r rune) bool { return r == ',' }))
+	m.SetResources(resources)
 
 	var nodeSelector labels.Selector
 	if ns, err := labels.Parse(flags.NodeSelector); err != nil {

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -21,17 +21,19 @@ import (
 )
 
 type Cluster struct {
-	mu        sync.RWMutex
-	nodes     map[string]*Node
-	pods      map[objectKey]*Pod
-	resources []v1.ResourceName
+	mu                   sync.RWMutex
+	nodes                map[string]*Node
+	pods                 map[objectKey]*Pod
+	resources            []v1.ResourceName
+	normalizedAllocation bool
 }
 
-func NewCluster() *Cluster {
+func NewCluster(normalizedAllocation bool) *Cluster {
 	return &Cluster{
-		nodes:     map[string]*Node{},
-		pods:      map[objectKey]*Pod{},
-		resources: []v1.ResourceName{v1.ResourceCPU},
+		nodes:                map[string]*Node{},
+		pods:                 map[objectKey]*Pod{},
+		resources:            []v1.ResourceName{v1.ResourceCPU},
+		normalizedAllocation: normalizedAllocation,
 	}
 }
 func (c *Cluster) AddNode(node *Node) *Node {
@@ -165,7 +167,7 @@ func (c *Cluster) Stats() Stats {
 		st.NumNodes++
 		st.Nodes = append(st.Nodes, n)
 		addResources(st.AllocatableResources, n.Allocatable())
-		addResources(st.UsedResources, n.Used())
+		addResources(st.UsedResources, n.UsedNormalized(c.normalizedAllocation))
 	}
 	return st
 }

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestClusterAddNode(t *testing.T) {
-	cluster := model.NewCluster()
+	cluster := model.NewCluster(false)
 
 	if got := len(cluster.Stats().Nodes); got != 0 {
 		t.Errorf("expected 0 nodes, got %d", got)
@@ -63,7 +63,7 @@ func TestClusterAddNode(t *testing.T) {
 }
 
 func TestClusterGetNodeByProviderID(t *testing.T) {
-	cluster := model.NewCluster()
+	cluster := model.NewCluster(false)
 
 	_, ok := cluster.GetNode("mynode-id")
 	if ok {
@@ -88,7 +88,7 @@ func TestClusterGetNodeByProviderID(t *testing.T) {
 }
 
 func TestClusterGetNodeByName(t *testing.T) {
-	cluster := model.NewCluster()
+	cluster := model.NewCluster(false)
 
 	_, ok := cluster.GetNodeByName("mynode")
 	if ok {
@@ -105,7 +105,7 @@ func TestClusterGetNodeByName(t *testing.T) {
 }
 
 func TestClusterUpdateNode(t *testing.T) {
-	cluster := model.NewCluster()
+	cluster := model.NewCluster(false)
 
 	n1 := testNode("mynode")
 	n1.Status.Allocatable = v1.ResourceList{
@@ -135,7 +135,7 @@ func TestClusterUpdateNode(t *testing.T) {
 }
 
 func TestClusterAddPod(t *testing.T) {
-	cluster := model.NewCluster()
+	cluster := model.NewCluster(false)
 
 	n := testNode("mynode")
 	n.Spec.ProviderID = "mynode-id"
@@ -175,7 +175,7 @@ func TestClusterAddPod(t *testing.T) {
 }
 
 func TestClusterDeleteNodeDeletesPods(t *testing.T) {
-	cluster := model.NewCluster()
+	cluster := model.NewCluster(false)
 
 	// add a node and pod bound to that node
 	n := testNode("mynode")


### PR DESCRIPTION
*Issue #, if available:* This is actually a feature request, so I haven't created an issue for it before

*Description of changes:*

Some times, depending how your workloads are structured in terms of resources requests, mostly if the amount of cpu and memory requested do not follow an appropriated ratio, you can end up with a cluster allocation like the one in the following example:

1. CPU allocation
![image](https://github.com/user-attachments/assets/1f22bab2-a423-4078-9640-76a634d94fe8)

2. Memory Allocation
![image](https://github.com/user-attachments/assets/c2a1abb8-90e7-4bf0-bb1d-ffcc937f80b0)

As you can see, the allocation on each dimension (CPU and Memory) is relatively low, and it is hard to tell if Karpenter for instance, is doing a good job on consolidating and choosing the right instance type for bin-packing the workloads.

However, if eks-node-viewer would offer a flag to enable a normalized view of resources, meaning, if when watching for CPU resources, the memory allocation on a given node is higher than the cpu, the viewer would normalize the CPU allocation on the node to match the memory allocation, increasing it to show the node is actually higher allocated on CPU as well, and vice versa.

For the example above, when this logic is applied, you can actually see the cluster is 99.6% allocated, clearly showing that Karpenter is doing a good job and there is pretty much no wasted resources from a normalized point of view.
![image](https://github.com/user-attachments/assets/4478de9a-1426-4b0b-b74d-ef54917e8e28)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
