### PR TITLE
add support for nodes managed by Spot Ocean

### DIFF
--- a/pkg/model/node.go
+++ b/pkg/model/node.go
@@ -78,12 +78,14 @@ func NewNodeFromNodeClaim(nc *karpv1.NodeClaim) *Node {
 
 func (n *Node) IsOnDemand() bool {
 	return n.node.Labels["karpenter.sh/capacity-type"] == "on-demand" ||
-		n.node.Labels["eks.amazonaws.com/capacityType"] == "ON_DEMAND"
+		n.node.Labels["eks.amazonaws.com/capacityType"] == "ON_DEMAND" ||
+		n.node.Labels["spotinst.io/node-lifecycle"] == "od"
 }
 
 func (n *Node) IsSpot() bool {
 	return n.node.Labels["karpenter.sh/capacity-type"] == "spot" ||
-		n.node.Labels["eks.amazonaws.com/capacityType"] == "SPOT"
+		n.node.Labels["eks.amazonaws.com/capacityType"] == "SPOT" ||
+		n.node.Labels["spotinst.io/node-lifecycle"] == "spot"
 }
 
 func (n *Node) IsFargate() bool {

--- a/pkg/model/node_test.go
+++ b/pkg/model/node_test.go
@@ -39,7 +39,7 @@ func TestNewNode(t *testing.T) {
 	n := testNode("mynode")
 	node := model.NewNode(n)
 	if exp, got := "mynode", node.Name(); exp != got {
-		t.Errorf("expeted Name == %s, got %s", exp, got)
+		t.Errorf("expected Name == %s, got %s", exp, got)
 	}
 }
 
@@ -47,10 +47,10 @@ func TestNodeTypeUnknown(t *testing.T) {
 	n := testNode("mynode")
 	node := model.NewNode(n)
 	if node.IsOnDemand() {
-		t.Errorf("exepcted to not be on-demand")
+		t.Errorf("expected to not be on-demand")
 	}
 	if node.IsSpot() {
-		t.Errorf("exepcted to not be spot")
+		t.Errorf("expected to not be spot")
 	}
 }
 
@@ -58,6 +58,7 @@ func TestNodeTypeOnDemand(t *testing.T) {
 	for label, value := range map[string]string{
 		"karpenter.sh/capacity-type":     "on-demand",
 		"eks.amazonaws.com/capacityType": "ON_DEMAND",
+		"spotinst.io/node-lifecycle":     "od",
 	} {
 		n := testNode("mynode")
 		n.Labels = map[string]string{
@@ -65,13 +66,13 @@ func TestNodeTypeOnDemand(t *testing.T) {
 		}
 		node := model.NewNode(n)
 		if !node.IsOnDemand() {
-			t.Errorf("exepcted on-demand")
+			t.Errorf("expected on-demand")
 		}
 		if node.IsSpot() {
-			t.Errorf("exepcted to not be spot")
+			t.Errorf("expected to not be spot")
 		}
 		if node.IsFargate() {
-			t.Errorf("exepcted to not be fargate")
+			t.Errorf("expected to not be fargate")
 		}
 	}
 }
@@ -80,6 +81,7 @@ func TestNodeTypeSpot(t *testing.T) {
 	for label, value := range map[string]string{
 		"karpenter.sh/capacity-type":     "spot",
 		"eks.amazonaws.com/capacityType": "SPOT",
+		"spotinst.io/node-lifecycle":     "spot",
 	} {
 		n := testNode("mynode")
 		n.Labels = map[string]string{
@@ -87,13 +89,13 @@ func TestNodeTypeSpot(t *testing.T) {
 		}
 		node := model.NewNode(n)
 		if node.IsOnDemand() {
-			t.Errorf("exepcted to not be on-demand")
+			t.Errorf("expected to not be on-demand")
 		}
 		if !node.IsSpot() {
-			t.Errorf("exepcted to be spot")
+			t.Errorf("expected to be spot")
 		}
 		if node.IsFargate() {
-			t.Errorf("exepcted to not be fargate")
+			t.Errorf("expected to not be fargate")
 		}
 	}
 }
@@ -108,13 +110,13 @@ func TestNodeTypeFargate(t *testing.T) {
 		}
 		node := model.NewNode(n)
 		if node.IsOnDemand() {
-			t.Errorf("exepcted to not be on-demand")
+			t.Errorf("expected to not be on-demand")
 		}
 		if node.IsSpot() {
-			t.Errorf("exepcted to not be spot")
+			t.Errorf("expected to not be spot")
 		}
 		if !node.IsFargate() {
-			t.Errorf("exepcted to be fargate")
+			t.Errorf("expected to be fargate")
 		}
 	}
 }
@@ -129,16 +131,16 @@ func TestNodeTypeAuto(t *testing.T) {
 		}
 		node := model.NewNode(n)
 		if node.IsOnDemand() {
-			t.Errorf("exepcted to not be on-demand")
+			t.Errorf("expected to not be on-demand")
 		}
 		if node.IsSpot() {
-			t.Errorf("exepcted to not be spot")
+			t.Errorf("expected to not be spot")
 		}
 		if node.IsFargate() {
-			t.Errorf("exepcted to not be fargate")
+			t.Errorf("expected to not be fargate")
 		}
 		if !node.IsAuto() {
-			t.Errorf("exepcted to be auto")
+			t.Errorf("expected to be auto")
 		}
 	}
 }


### PR DESCRIPTION
*Description of changes:*
Nodes managed by Spot Ocean have different labels to distinguish between on-demand and spot instances.
Labels in docs: https://docs.spot.io/ocean/features/labels-and-taints?id=spotinstionode-lifecycle
Also fixed some typos in node_test.go.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
