### PR TITLE
feat(ui): Show eks cluster name in the main UI

### DIFF
--- a/cmd/eks-node-viewer/main.go
+++ b/cmd/eks-node-viewer/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -73,7 +74,13 @@ func main() {
 	if err != nil {
 		log.Fatalf("creating style, %s", err)
 	}
-	m := model.NewUIModel(strings.Split(flags.ExtraLabels, ","), flags.NodeSort, style)
+
+	out, err := exec.Command("kubectl", "config", "view", "--minify", "-o", "jsonpath='{.clusters[].name}'").Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	m := model.NewUIModel(strings.Split(flags.ExtraLabels, ","), flags.NodeSort, style, string(out))
 	m.DisablePricing = flags.DisablePricing
 	m.SetResources(strings.FieldsFunc(flags.Resources, func(r rune) bool { return r == ',' }))
 

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -25,13 +25,15 @@ type Cluster struct {
 	nodes     map[string]*Node
 	pods      map[objectKey]*Pod
 	resources []v1.ResourceName
+	name      string
 }
 
-func NewCluster() *Cluster {
+func NewCluster(context string) *Cluster {
 	return &Cluster{
 		nodes:     map[string]*Node{},
 		pods:      map[objectKey]*Pod{},
 		resources: []v1.ResourceName{v1.ResourceCPU},
+		name:      context,
 	}
 }
 func (c *Cluster) AddNode(node *Node) *Node {

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestClusterAddNode(t *testing.T) {
-	cluster := model.NewCluster()
+	cluster := model.NewCluster("mycontext-name")
 
 	if got := len(cluster.Stats().Nodes); got != 0 {
 		t.Errorf("expected 0 nodes, got %d", got)
@@ -63,7 +63,7 @@ func TestClusterAddNode(t *testing.T) {
 }
 
 func TestClusterGetNodeByProviderID(t *testing.T) {
-	cluster := model.NewCluster()
+	cluster := model.NewCluster("mycontext-name")
 
 	_, ok := cluster.GetNode("mynode-id")
 	if ok {
@@ -88,7 +88,7 @@ func TestClusterGetNodeByProviderID(t *testing.T) {
 }
 
 func TestClusterGetNodeByName(t *testing.T) {
-	cluster := model.NewCluster()
+	cluster := model.NewCluster("mycontext-name")
 
 	_, ok := cluster.GetNodeByName("mynode")
 	if ok {
@@ -105,7 +105,7 @@ func TestClusterGetNodeByName(t *testing.T) {
 }
 
 func TestClusterUpdateNode(t *testing.T) {
-	cluster := model.NewCluster()
+	cluster := model.NewCluster("mycontext-name")
 
 	n1 := testNode("mynode")
 	n1.Status.Allocatable = v1.ResourceList{
@@ -135,7 +135,7 @@ func TestClusterUpdateNode(t *testing.T) {
 }
 
 func TestClusterAddPod(t *testing.T) {
-	cluster := model.NewCluster()
+	cluster := model.NewCluster("mycontext-name")
 
 	n := testNode("mynode")
 	n.Spec.ProviderID = "mynode-id"
@@ -175,7 +175,7 @@ func TestClusterAddPod(t *testing.T) {
 }
 
 func TestClusterDeleteNodeDeletesPods(t *testing.T) {
-	cluster := model.NewCluster()
+	cluster := model.NewCluster("mycontext-name")
 
 	// add a node and pod bound to that node
 	n := testNode("mynode")

--- a/pkg/model/uimodel.go
+++ b/pkg/model/uimodel.go
@@ -54,7 +54,7 @@ type UIModel struct {
 	DisablePricing bool
 }
 
-func NewUIModel(extraLabels []string, nodeSort string, style *Style) *UIModel {
+func NewUIModel(extraLabels []string, nodeSort string, style *Style, context string) *UIModel {
 	pager := paginator.New()
 	pager.Type = paginator.Dots
 	pager.ActiveDot = activeDot
@@ -62,7 +62,7 @@ func NewUIModel(extraLabels []string, nodeSort string, style *Style) *UIModel {
 	return &UIModel{
 		// red to green
 		progress:    progress.New(style.gradient),
-		cluster:     NewCluster(),
+		cluster:     NewCluster(context),
 		extraLabels: extraLabels,
 		paginator:   pager,
 		nodeSorter:  makeNodeSorter(nodeSort),
@@ -88,6 +88,10 @@ func (u *UIModel) View() string {
 	})
 
 	ctw := text.NewColorTabWriter(&b, 0, 8, 1)
+
+	fmt.Fprintln(&b, "Viewing cluster: ", u.cluster.name)
+	fmt.Fprintln(&b)
+
 	u.writeClusterSummary(u.cluster.resources, stats, ctw)
 	ctw.Flush()
 	u.progress.ShowPercentage = true
@@ -122,6 +126,7 @@ func (u *UIModel) View() string {
 
 	fmt.Fprintln(&b, u.paginator.View())
 	fmt.Fprintln(&b, helpStyle("←/→ page • q: quit"))
+
 	return b.String()
 }
 


### PR DESCRIPTION
*Issue #, if available:*
No linked issue.


*Description of changes:*
This feature retrieve and show the current EKS cluster being shown in the eks-node-viewer main UI.
It can be useful when working with more than one cluster (one or more clusters per environment for example).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.