### PR TITLE
Display maximum number of pods for each node

### DIFF
--- a/pkg/model/uimodel.go
+++ b/pkg/model/uimodel.go
@@ -148,7 +148,8 @@ func (u *UIModel) writeNodeInfo(n *Node, w io.Writer, resources []v1.ResourceNam
 			if !n.HasPrice() || u.DisablePricing {
 				priceLabel = ""
 			}
-			fmt.Fprintf(w, "%s\t%s\t%s\t(%d pods)\t%s%s", n.Name(), res, u.progress.ViewAs(pct), n.NumPods(), n.InstanceType(), priceLabel)
+			maxPods, _ := allocatable.Pods().AsInt64()
+			fmt.Fprintf(w, "%s\t%s\t%s\t(%d/%d pods)\t%s%s", n.Name(), res, u.progress.ViewAs(pct), n.NumPods(), maxPods, n.InstanceType(), priceLabel)
 
 			// node compute type
 			if n.IsOnDemand() {


### PR DESCRIPTION
This PR adds maximum number of pods for each node:

![Screenshot 2025-07-04 at 16 07 01](https://github.com/user-attachments/assets/f9fa4c1f-d64a-4b63-be46-d7ecf240c689)


Found that it would be useful to show in case of mixed nodes in the cluster with different limits – especially some instance types like `c7a.medium` has a low limit and it might be surprising for people.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
