### PR TITLE
Add DRA ResourceClaim tracking for device allocation visualization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TEST_PKGS=./pkg/... ./cmd/...
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[33m%-20s\033[0m %s\n", $$1, $$2}'
 
-build: generate ## Build
+build: ## Build (uses committed generated files; run `make generate` to refresh them)
 	go build -ldflags="-s -w -X main.version=local -X main.builtBy=Makefile" ./cmd/eks-node-viewer
 
 goreleaser: ## Release snapshot

--- a/cmd/eks-node-viewer/main.go
+++ b/cmd/eks-node-viewer/main.go
@@ -66,6 +66,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("creating node claim client, %s", err)
 	}
+	resourceClaimClient, err := client.NewResourceClaims(flags.Kubeconfig, flags.Context)
+	if err != nil {
+		log.Printf("creating resource claim client (DRA not available): %s", err)
+		resourceClaimClient = nil
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 
 	pprov := aws.NewStaticPricingProvider()
@@ -92,7 +97,7 @@ func main() {
 		}
 		pprov = aws.NewPricingProvider(ctx, cfg)
 	}
-	controller := client.NewController(cs, nodeClaimClient, m, nodeSelector, pprov)
+	controller := client.NewController(cs, nodeClaimClient, resourceClaimClient, m, nodeSelector, pprov)
 
 	controller.Start(ctx)
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,6 +17,7 @@ package client
 import (
 	"strings"
 
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -50,6 +51,26 @@ func NewNodeClaims(kubeconfig, context string) (*rest.RESTClient, error) {
 	scheme.Scheme.AddKnownTypes(gv,
 		&karpv1.NodeClaim{},
 		&karpv1.NodeClaimList{})
+
+	config := *c
+	config.ContentConfig.GroupVersion = &gv
+	config.APIPath = "/apis"
+	config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	config.UserAgent = rest.DefaultKubernetesUserAgent()
+
+	return rest.RESTClientFor(&config)
+}
+
+func NewResourceClaims(kubeconfig, context string) (*rest.RESTClient, error) {
+	c, err := getConfig(kubeconfig, context)
+	if err != nil {
+		return nil, err
+	}
+
+	gv := schema.GroupVersion{Group: "resource.k8s.io", Version: "v1"}
+	scheme.Scheme.AddKnownTypes(gv,
+		&resourcev1.ResourceClaim{},
+		&resourcev1.ResourceClaimList{})
 
 	config := *c
 	config.ContentConfig.GroupVersion = &gv

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -70,7 +70,9 @@ func NewResourceClaims(kubeconfig, context string) (*rest.RESTClient, error) {
 	gv := schema.GroupVersion{Group: "resource.k8s.io", Version: "v1"}
 	scheme.Scheme.AddKnownTypes(gv,
 		&resourcev1.ResourceClaim{},
-		&resourcev1.ResourceClaimList{})
+		&resourcev1.ResourceClaimList{},
+		&resourcev1.ResourceSlice{},
+		&resourcev1.ResourceSliceList{})
 
 	config := *c
 	config.ContentConfig.GroupVersion = &gv

--- a/pkg/client/controller.go
+++ b/pkg/client/controller.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,20 +34,22 @@ import (
 )
 
 type Controller struct {
-	kubeClient      *kubernetes.Clientset
-	uiModel         *model.UIModel
-	pricing         pricing.Provider
-	nodeSelector    labels.Selector
-	nodeClaimClient *rest.RESTClient
+	kubeClient           *kubernetes.Clientset
+	uiModel              *model.UIModel
+	pricing              pricing.Provider
+	nodeSelector         labels.Selector
+	nodeClaimClient      *rest.RESTClient
+	resourceClaimClient  *rest.RESTClient
 }
 
-func NewController(kubeClient *kubernetes.Clientset, nodeClaimClient *rest.RESTClient, uiModel *model.UIModel, nodeSelector labels.Selector, pricing pricing.Provider) *Controller {
+func NewController(kubeClient *kubernetes.Clientset, nodeClaimClient *rest.RESTClient, resourceClaimClient *rest.RESTClient, uiModel *model.UIModel, nodeSelector labels.Selector, pricing pricing.Provider) *Controller {
 	c := &Controller{
-		kubeClient:      kubeClient,
-		uiModel:         uiModel,
-		pricing:         pricing,
-		nodeSelector:    nodeSelector,
-		nodeClaimClient: nodeClaimClient,
+		kubeClient:          kubeClient,
+		uiModel:            uiModel,
+		pricing:            pricing,
+		nodeSelector:       nodeSelector,
+		nodeClaimClient:    nodeClaimClient,
+		resourceClaimClient: resourceClaimClient,
 	}
 	pricing.OnUpdate(c.RefreshNodePrices)
 	return c
@@ -61,6 +64,13 @@ func (m Controller) Start(ctx context.Context) {
 	// If a NodeClaims Get returns an error, then don't startup the nodeclaims controller since the CRD is not registered
 	if err := m.nodeClaimClient.Get().Do(ctx).Error(); err == nil {
 		m.startNodeClaimWatch(ctx, cluster)
+	}
+
+	// If ResourceClaims API is available, watch for DRA allocations
+	if m.resourceClaimClient != nil {
+		if err := m.resourceClaimClient.Get().Do(ctx).Error(); err == nil {
+			m.startResourceClaimWatch(ctx, cluster)
+		}
 	}
 }
 
@@ -189,6 +199,73 @@ func (m Controller) startPodWatch(ctx context.Context, cluster *model.Cluster) {
 		},
 	)
 	go podController.Run(ctx.Done())
+}
+
+func (m Controller) startResourceClaimWatch(ctx context.Context, cluster *model.Cluster) {
+	resourceClaimWatchList := cache.NewListWatchFromClient(m.resourceClaimClient, "resourceclaims",
+		v1.NamespaceAll, fields.Everything())
+	_, resourceClaimController := cache.NewInformer(
+		resourceClaimWatchList,
+		&resourcev1.ResourceClaim{},
+		time.Second*0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				m.handleResourceClaim(cluster, obj.(*resourcev1.ResourceClaim))
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				m.handleResourceClaim(cluster, newObj.(*resourcev1.ResourceClaim))
+			},
+			DeleteFunc: func(obj interface{}) {
+				claim := ignoreDeletedFinalStateUnknown(obj).(*resourcev1.ResourceClaim)
+				m.handleResourceClaimDelete(cluster, claim)
+			},
+		},
+	)
+	go resourceClaimController.Run(ctx.Done())
+}
+
+// draDriverToResource maps DRA driver names to allocatable resource names.
+var draDriverToResource = map[string]string{
+	"neuron.aws.com": "aws.amazon.com/neuron",
+}
+
+// handleResourceClaim processes an allocated ResourceClaim and updates node DRA usage.
+func (m Controller) handleResourceClaim(cluster *model.Cluster, claim *resourcev1.ResourceClaim) {
+	if claim.Status.Allocation == nil {
+		return
+	}
+
+	// Group allocated devices by node (pool name) and resource name
+	nodeDeviceCounts := map[string]map[string]int64{} // nodeName -> resourceName -> count
+	for _, result := range claim.Status.Allocation.Devices.Results {
+		nodeName := result.Pool
+		if nodeName == "" {
+			continue
+		}
+		resourceName := result.Driver
+		if mapped, ok := draDriverToResource[result.Driver]; ok {
+			resourceName = mapped
+		}
+		if nodeDeviceCounts[nodeName] == nil {
+			nodeDeviceCounts[nodeName] = map[string]int64{}
+		}
+		nodeDeviceCounts[nodeName][resourceName]++
+	}
+
+	claimUID := string(claim.UID)
+	for nodeName, resourceCounts := range nodeDeviceCounts {
+		if node, ok := cluster.GetNodeByName(nodeName); ok {
+			node.AddDRAClaim(claimUID, resourceCounts)
+		}
+	}
+}
+
+// handleResourceClaimDelete removes DRA device allocations when a claim is deleted.
+func (m Controller) handleResourceClaimDelete(cluster *model.Cluster, claim *resourcev1.ResourceClaim) {
+	claimUID := string(claim.UID)
+	cluster.ForEachNode(func(n *model.Node) {
+		n.DeleteDRAClaim(claimUID)
+	})
 }
 
 func (m Controller) updatePrice(node *model.Node) {

--- a/pkg/client/controller.go
+++ b/pkg/client/controller.go
@@ -70,6 +70,9 @@ func (m Controller) Start(ctx context.Context) {
 	if m.resourceClaimClient != nil {
 		if err := m.resourceClaimClient.Get().Do(ctx).Error(); err == nil {
 			m.startResourceClaimWatch(ctx, cluster)
+			// ResourceSlices advertise DRA device capacity (e.g. Neuron on trn3,
+			// which is not reported in node.Status.Allocatable).
+			m.startResourceSliceWatch(ctx, cluster)
 		}
 	}
 }
@@ -224,9 +227,62 @@ func (m Controller) startResourceClaimWatch(ctx context.Context, cluster *model.
 	go resourceClaimController.Run(ctx.Done())
 }
 
+func (m Controller) startResourceSliceWatch(ctx context.Context, cluster *model.Cluster) {
+	resourceSliceWatchList := cache.NewListWatchFromClient(m.resourceClaimClient, "resourceslices",
+		v1.NamespaceAll, fields.Everything())
+	_, resourceSliceController := cache.NewInformer(
+		resourceSliceWatchList,
+		&resourcev1.ResourceSlice{},
+		time.Second*0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				m.handleResourceSlice(cluster, obj.(*resourcev1.ResourceSlice))
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				m.handleResourceSlice(cluster, newObj.(*resourcev1.ResourceSlice))
+			},
+			DeleteFunc: func(obj interface{}) {
+				slice := ignoreDeletedFinalStateUnknown(obj).(*resourcev1.ResourceSlice)
+				m.handleResourceSliceDelete(cluster, slice)
+			},
+		},
+	)
+	go resourceSliceController.Run(ctx.Done())
+}
+
 // draDriverToResource maps DRA driver names to allocatable resource names.
 var draDriverToResource = map[string]string{
 	"neuron.aws.com": "aws.amazon.com/neuron",
+}
+
+// handleResourceSlice records the DRA device capacity a slice advertises for
+// its node, so DRA-only resources (e.g. Neuron on trn3) have a denominator.
+func (m Controller) handleResourceSlice(cluster *model.Cluster, slice *resourcev1.ResourceSlice) {
+	if slice.Spec.NodeName == nil || *slice.Spec.NodeName == "" {
+		return
+	}
+	node, ok := cluster.GetNodeByName(*slice.Spec.NodeName)
+	if !ok {
+		return
+	}
+
+	// Only map drivers we know how to surface; ignore others (e.g. dra.net).
+	resourceName, known := draDriverToResource[slice.Spec.Driver]
+	if !known {
+		return
+	}
+
+	node.SetDRASlice(slice.Name, resourceName, int64(len(slice.Spec.Devices)))
+}
+
+// handleResourceSliceDelete removes the DRA device capacity a slice advertised.
+func (m Controller) handleResourceSliceDelete(cluster *model.Cluster, slice *resourcev1.ResourceSlice) {
+	if slice.Spec.NodeName == nil || *slice.Spec.NodeName == "" {
+		return
+	}
+	if node, ok := cluster.GetNodeByName(*slice.Spec.NodeName); ok {
+		node.DeleteDRASlice(slice.Name)
+	}
 }
 
 // handleResourceClaim processes an allocated ResourceClaim and updates node DRA usage.

--- a/pkg/model/node.go
+++ b/pkg/model/node.go
@@ -36,6 +36,13 @@ type objectKey struct {
 	namespace string
 	name      string
 }
+
+// draSliceAlloc records the device capacity a single DRA ResourceSlice
+// advertises: which allocatable resource name it maps to and how many devices.
+type draSliceAlloc struct {
+	resourceName string
+	count        int64
+}
 type Node struct {
 	mu                    sync.RWMutex
 	visible               bool
@@ -44,6 +51,7 @@ type Node struct {
 	used                  v1.ResourceList
 	draUsed               map[string]int64 // resource name -> count of devices allocated via DRA
 	draClaims             map[string]map[string]int64 // claimUID -> resource name -> device count
+	draSlices             map[string]draSliceAlloc // ResourceSlice name -> advertised DRA device capacity
 	Price                 float64
 	nodeclaimCreationTime time.Time
 }
@@ -52,9 +60,10 @@ func NewNode(n *v1.Node) *Node {
 	node := &Node{
 		node:      *n,
 		pods:      map[objectKey]*Pod{},
-		used:      v1.ResourceList{},
-		draUsed:   map[string]int64{},
-		draClaims: map[string]map[string]int64{},
+		used:           v1.ResourceList{},
+		draUsed:        map[string]int64{},
+		draClaims:      map[string]map[string]int64{},
+		draSlices:      map[string]draSliceAlloc{},
 	}
 
 	return node
@@ -175,8 +184,25 @@ func (n *Node) DeletePod(namespace string, name string) {
 func (n *Node) Allocatable() v1.ResourceList {
 	n.mu.RLock()
 	defer n.mu.RUnlock()
-	// shouldn't be modified so it's safe to return
-	return n.node.Status.Allocatable
+	// Fast path: no DRA-advertised capacity, return the node's allocatable as-is.
+	if len(n.draSlices) == 0 {
+		// shouldn't be modified so it's safe to return
+		return n.node.Status.Allocatable
+	}
+	// Merge DRA device capacity (e.g. Neuron on trn3, advertised only via
+	// ResourceSlices) into the allocatable list so it shows as the denominator.
+	allocatable := v1.ResourceList{}
+	for rn, q := range n.node.Status.Allocatable {
+		allocatable[rn] = q.DeepCopy()
+	}
+	for _, slice := range n.draSlices {
+		if slice.count > 0 {
+			existing := allocatable[v1.ResourceName(slice.resourceName)]
+			existing.Add(k8sresource.MustParse(fmt.Sprintf("%d", slice.count)))
+			allocatable[v1.ResourceName(slice.resourceName)] = existing
+		}
+	}
+	return allocatable
 }
 
 func (n *Node) Used() v1.ResourceList {
@@ -328,6 +354,24 @@ func (n *Node) DeleteDRAClaim(claimUID string) {
 		}
 		delete(n.draClaims, claimUID)
 	}
+}
+
+// SetDRASlice records the DRA device capacity advertised by a single
+// ResourceSlice (identified by sliceName) for this node. This capacity is
+// merged into Allocatable so DRA-only resources (e.g. Neuron on trn3, which is
+// not present in node.Status.Allocatable) have a usable denominator. A node may
+// have multiple slices per driver; each is tracked independently by name.
+func (n *Node) SetDRASlice(sliceName, resourceName string, count int64) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.draSlices[sliceName] = draSliceAlloc{resourceName: resourceName, count: count}
+}
+
+// DeleteDRASlice removes the DRA device capacity advertised by a ResourceSlice.
+func (n *Node) DeleteDRASlice(sliceName string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	delete(n.draSlices, sliceName)
 }
 
 // DRAUsed returns the DRA device allocation counts.

--- a/pkg/model/node.go
+++ b/pkg/model/node.go
@@ -22,6 +22,7 @@ import (
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	v1 "k8s.io/api/core/v1"
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
@@ -41,15 +42,19 @@ type Node struct {
 	node                  v1.Node
 	pods                  map[objectKey]*Pod
 	used                  v1.ResourceList
+	draUsed               map[string]int64 // resource name -> count of devices allocated via DRA
+	draClaims             map[string]map[string]int64 // claimUID -> resource name -> device count
 	Price                 float64
 	nodeclaimCreationTime time.Time
 }
 
 func NewNode(n *v1.Node) *Node {
 	node := &Node{
-		node: *n,
-		pods: map[objectKey]*Pod{},
-		used: v1.ResourceList{},
+		node:      *n,
+		pods:      map[objectKey]*Pod{},
+		used:      v1.ResourceList{},
+		draUsed:   map[string]int64{},
+		draClaims: map[string]map[string]int64{},
 	}
 
 	return node
@@ -181,6 +186,14 @@ func (n *Node) Used() v1.ResourceList {
 	for rn, q := range n.used {
 		used[rn] = q.DeepCopy()
 	}
+	// Merge DRA device allocations into the used resource list
+	for res, count := range n.draUsed {
+		if count > 0 {
+			existing := used[v1.ResourceName(res)]
+			existing.Add(k8sresource.MustParse(fmt.Sprintf("%d", count)))
+			used[v1.ResourceName(res)] = existing
+		}
+	}
 	return used
 }
 
@@ -287,6 +300,45 @@ func (n *Node) Pods() []*Pod {
 func (n *Node) HasPrice() bool {
 	// we use NaN for an unknown price, so if this is true the price is known
 	return n.Price == n.Price
+}
+
+// AddDRAClaim records DRA device allocations for a claim on this node.
+func (n *Node) AddDRAClaim(claimUID string, resourceCounts map[string]int64) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	// Remove old counts if this claim was already tracked
+	if old, ok := n.draClaims[claimUID]; ok {
+		for res, count := range old {
+			n.draUsed[res] -= count
+		}
+	}
+	n.draClaims[claimUID] = resourceCounts
+	for res, count := range resourceCounts {
+		n.draUsed[res] += count
+	}
+}
+
+// DeleteDRAClaim removes DRA device allocations for a claim from this node.
+func (n *Node) DeleteDRAClaim(claimUID string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if old, ok := n.draClaims[claimUID]; ok {
+		for res, count := range old {
+			n.draUsed[res] -= count
+		}
+		delete(n.draClaims, claimUID)
+	}
+}
+
+// DRAUsed returns the DRA device allocation counts.
+func (n *Node) DRAUsed() map[string]int64 {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	result := make(map[string]int64, len(n.draUsed))
+	for k, v := range n.draUsed {
+		result[k] = v
+	}
+	return result
 }
 
 var resourceLabelRe = regexp.MustCompile("eks-node-viewer/node-(.*?)-usage")

--- a/pkg/model/node_test.go
+++ b/pkg/model/node_test.go
@@ -188,3 +188,45 @@ func TestNodeNotReadyNoCondition(t *testing.T) {
 		})
 	}
 }
+
+const neuronResource = "aws.amazon.com/neuron"
+
+// On trn3, Neuron capacity is advertised only via DRA ResourceSlices, not in
+// node.Status.Allocatable. SetDRASlice must surface it through Allocatable.
+func TestNodeDRAAllocatableFromSlice(t *testing.T) {
+	node := model.NewNode(testNode("trn3-node"))
+
+	if q := node.Allocatable()[neuronResource]; !q.IsZero() {
+		t.Fatalf("expected no neuron allocatable before slice, got %s", q.String())
+	}
+
+	node.SetDRASlice("slice-a", neuronResource, 16)
+
+	q := node.Allocatable()[neuronResource]
+	if got := q.Value(); got != 16 {
+		t.Errorf("expected 16 neuron devices allocatable, got %d", got)
+	}
+}
+
+// Multiple slices for the same resource on one node must sum.
+func TestNodeDRAAllocatableMultipleSlices(t *testing.T) {
+	node := model.NewNode(testNode("trn3-node"))
+	node.SetDRASlice("slice-a", neuronResource, 16)
+	node.SetDRASlice("slice-b", neuronResource, 8)
+
+	q := node.Allocatable()[neuronResource]
+	if got := q.Value(); got != 24 {
+		t.Errorf("expected 24 neuron devices allocatable, got %d", got)
+	}
+}
+
+// Deleting a slice must remove its advertised capacity.
+func TestNodeDRAAllocatableDeleteSlice(t *testing.T) {
+	node := model.NewNode(testNode("trn3-node"))
+	node.SetDRASlice("slice-a", neuronResource, 16)
+	node.DeleteDRASlice("slice-a")
+
+	if q := node.Allocatable()[neuronResource]; !q.IsZero() {
+		t.Errorf("expected no neuron allocatable after delete, got %s", q.String())
+	}
+}


### PR DESCRIPTION
## Summary

  - Watch `ResourceClaim` objects to track DRA (Dynamic Resource Allocation) device usage per node
  - Enables visualization of devices managed by DRA drivers (e.g., AWS Neuron) that don't appear in traditional pod resource requests
  - Maps the `neuron.aws.com` DRA driver to the `aws.amazon.com/neuron` allocatable resource so the progress bar shows correct utilization
  - Gracefully degrades when the DRA API is not available on the cluster

  ## Usage

  ```bash
  # Neuron devices only
  eks-node-viewer --resources aws.amazon.com/neuron

  # CPU and Neuron devices together
  eks-node-viewer --resources cpu,aws.amazon.com/neuron

  # With node selector
  eks-node-viewer --resources cpu,aws.amazon.com/neuron --node-selector node-type=trn2

  # Alias for convenience
  alias eks-node-viewer-neuron="eks-node-viewer --resources cpu,aws.amazon.com/neuron"

  ```
  Example Output

![Screenshot-eks-node-viewer-neuron](https://github.com/user-attachments/assets/c361c59f-3f49-4302-af80-081677880c08)

  Test plan

  - [ ] Build succeeds with go build ./cmd/eks-node-viewer
  - [ ] Existing tests pass with make test
  - [ ] Neuron DRA allocation shows correct usage on trn2 nodes
  - [ ] Gracefully handles clusters without DRA API enabled
  - [ ] Works alongside traditional resource monitoring (cpu, memory)